### PR TITLE
[VIZ-1323] Wrong background color when importing XLSX file - part 2

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -5295,7 +5295,7 @@ function parse_theme_xml(data, opts) {
 			[t[2], t[3]] = [t[3], t[2]];
 		}
 	}
-	console.log('themes', themes);
+
 	return themes;
 }
 

--- a/xlsx.js
+++ b/xlsx.js
@@ -5282,6 +5282,20 @@ function parse_theme_xml(data, opts) {
 	if(!(t=data.match(themeltregex))) throw 'themeElements not found in theme';
 	parse_themeElements(t[0], opts);
 
+	// Issue: https://social.technet.microsoft.com/Forums/office/en-US/aa557c71-c45d-4881-ab41-49aa1ed745f4/theme-color-defaults?forum=excel
+	// Since from design reasons Excel changed how theme palletes are represented where pallete lt1 is on first place, following dk1, lt2, dk2
+	// but they didn't applied changes into theme.xml file where order of theme palletes is dk1, lt1, dk2, lt2. This causes bugs when parsing the style and colors
+	// when importing xlsx file and making Table from this file
+	if (themes.themeElements && themes.themeElements.clrScheme) {
+		let t = themes.themeElements.clrScheme;
+		if (t[0].name === 'dk1' && t[1].name === 'lt1') {
+			[t[0], t[1]] = [t[1], t[0]];
+		}
+		if (t[2].name === 'dk2' && t[3].name === 'lt2') {
+			[t[2], t[3]] = [t[3], t[2]];
+		}
+	}
+	console.log('themes', themes);
 	return themes;
 }
 


### PR DESCRIPTION
**Related JIRA issues**
https://socex-charts.atlassian.net/browse/VIZ-1323

**Description**
It seems that Excel, since 2016, in order to improve design, swaped black and white colors palettes in Theme colors pop-up. Now, when you open the color dialog, you get Theme colors palettes where you have in first place lt1 palette, followed by dk1 palette. But, in themes.xml file related to xlsx file the order is different (dk1, lt1, dk2, lt2). This resulted in parsing the wrong colors when we import XLSX file which use theme colors.
Added swapping of theme elements if that is the case in XLSX file.